### PR TITLE
Add common documents to onos-docs

### DIFF
--- a/docs/developers/community-info.md
+++ b/docs/developers/community-info.md
@@ -1,0 +1,34 @@
+# Contacts and Calendars
+
+## Mailing list
+
+The onos-config project currently leverages the `ONOS` developers mailing list:
+[onos-dev@onosprojects.org](onos-dev@onosproject.org)  
+**Note** We kindly ask to have the start of the subject to be `[onos-config]`
+
+## Slack channel
+The onos-config project has a slack channel in the `onosproject` slack: `#micro-onos`.
+If you want to join the `onosproject` slack please join [here](https://slackin.onosproject.org) and the subscribe to our channel.
+
+## Calendar
+
+The onos-config project leverages the common `ONOS` calendar which can be found at this 
+[link](https://www.google.com/calendar/embed?src=onosproject.org_6l261cnjim09dv9sulta3bgcmc%40group.calendar.google.com&ctz=America/Los_Angeles).  
+If you instead would like to add the calendar to your personal Google Calendar, please add the copy the following string  
+ ```
+ onosproject.org_6l261cnjim09dv9sulta3bgcmc@group.calendar.google.com
+ ```
+ to your external calendar (left bar in the Google Calendar online application).
+
+
+## Daily Stand-up 
+
+The onos-config project team holds a short stand-up every day at 10 AM PST, 6 PM GMT, 7 PM CET. 
+Feel free to join to learn what the team is up to and discuss your latest work with us.
+[meeting link](https://meet.google.com/pcn-wbei-utz) 
+
+## Technical Steering Team
+
+The technical steering team has PUBLIC and RECORDED meetings at 9 AM PST, 5 PM GMT, 6 PM CET on Wednesday every 2 weeks to discuss different topics. 
+You can find a detailed agenda and next meeting information [on the TST Wiki](https://wiki.onosproject.org/display/ONOSST/Technical+Steering+Team).
+ 

--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -1,0 +1,216 @@
+# Contributing to onosproject
+
+The ONOS team hopes for and welcomes contributions from the community at large.
+
+To become a contributor, you will first need to sign a CLA. After that, simply follow the process
+outlined below for submitting your patches on GitHub.
+
+## Workflow
+Contributions are accepted via GitHub Pull Requests submitted from the 
+developer's own Fork of the onos-config repository. The following diagram illustrates the steps
+required to establish such a Fork and to create a Pull Request.
+
+![Git workflow](images/contributing_workflow.png)
+
+In the following subsections, we explain the contribution workflow for one of the repositories (e.g. onos-config). The same workflow can be used
+for other repos under [onosproject](https://github.com/onosproject).
+
+### 1. Fork on GitHub
+
+1. Visit https://github.com/onosproject/onos-config 
+2. Click `Fork` button (top right) to establish your own GitHub repository fork.
+
+### 2. Clone Fork
+
+The `onos-config` code should be placed under your `GOPATH` (per [Go workspace conventions][go-workspace])
+using the following procedure:
+
+[go-workspace]: https://golang.org/doc/code.html#Workspaces
+
+If you have not set and exported the `GOPATH` environment variable, please do so:
+
+```sh
+export GOPATH=$(go env GOPATH)
+```
+
+Similarly, set and export the `GIT_USER` environment variable to match your github profile name:
+
+```sh
+export GIT_USER={your github profile name}
+```
+
+Then, clone your fork of the `onos-config` repository:
+
+```sh
+ONOS_ROOT=$GOPATH/src/github.com/onosproject
+mkdir -p $ONOS_ROOT && cd $ONOS_ROOT
+
+git clone https://github.com/$GIT_USER/onos-config.git
+# or: git clone git@github.com:$GIT_USER/onos-config.git
+
+cd $ONOS_ROOT/onos-config
+git remote add upstream https://github.com/onosproject/onos-config.git
+# or: git remote add upstream git@github.com:onosproject/onos-config.git
+
+# Never push to upstream master
+git remote set-url --push upstream no_push
+
+# Confirm that your remotes make sense:
+git remote -v
+```
+
+### 3. Branch
+
+Get your local master up to date:
+
+```sh
+cd $GOPATH/src/github.com/onosproject/onos-config
+git fetch upstream
+git checkout master
+git rebase upstream/master
+```
+
+Branch from it:
+```sh
+git checkout -b myfeature
+```
+
+Then edit code on the `myfeature` branch.
+
+### 4. Keep Branch in Sync
+
+While on your _myfeature_ branch
+
+```sh
+git fetch upstream
+git rebase upstream/master
+```
+
+Please don't use `git pull` instead of the above `fetch` / `rebase`. `git pull`
+does a merge, which leaves merge commits. These make the commit history messy
+and violate the principle that commits ought to be individually understandable
+and useful (see below). You can also consider changing your `.git/config` file via
+`git config branch.autoSetupRebase always` to change the behavior of `git pull`.
+
+### 5. Commit
+
+Commit your changes.
+
+```sh
+git commit
+```
+
+If you make other changes pleas add them to a new commit and thus keep 
+the history of your work.  
+Your branch, after you open a pull request,
+will be merged with a _squash and commit_ strategy, thus showing as only one commit.
+
+### 6. Push
+
+When ready to review (or just to establish an offsite backup or your work),
+push your branch to your fork on `github.com`:
+
+```sh
+git push origin myfeature
+```
+
+### 7. Create a Pull Request
+
+1. Visit your fork at `https://github.com/$user/onos-config`
+2. Click the `Compare & Pull Request` button next to your `myfeature` branch.
+
+Please follow the [pull request guidelines](pull_requests.md) .
+
+_If you have upstream write access_, please refrain from using the GitHub UI for
+creating PRs, because GitHub will create the PR branch inside the main
+repository rather than inside your fork.
+
+#### Get a Code Review
+
+Once your pull request has been opened it will be assigned to one or more
+reviewers.  Those reviewers will do a thorough code review, looking for
+correctness, bugs, opportunities for improvement, documentation and comments,
+and style.
+
+Commit changes made in response to review comments to the same branch on your
+fork.
+
+Very small PRs are easy to review.  Very large PRs are very difficult to review.
+
+#### Squash and Merge
+
+Upon merge (by either you or your reviewer), all commits left on the review
+branch should represent meaningful milestones or units of work.  Use commits to
+add clarity to the development and review process.
+
+Before merging a PR, squash any _fix review feedback_, _typo_, _merged_, and
+_rebased_ sorts of commits.
+
+It is not imperative that every commit in a PR compile and pass tests
+independently, but it is worth striving for.
+
+In particular, if you happened to have used `git merge` and have merge
+commits, please squash those away: they do not meet the above test.
+
+A nifty way to manage the commits in your PR is to do an [interactive
+rebase](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History),
+which will let you tell git what to do with every commit:
+
+```sh
+git fetch upstream
+git rebase -i upstream/master
+```
+
+For mass automated fixups (e.g. automated doc formatting), use one or more
+commits for the changes to tooling and a final commit to apply the fixup en
+masse. This makes reviews easier.
+
+### How to Revert a Commit
+
+In case you wish to revert a commit, use the following instructions.
+
+_If you have upstream write access_, please refrain from using the
+`Revert` button in the GitHub UI for creating the PR, because GitHub
+will create the PR branch inside the main repository rather than inside your fork.
+
+#### 1. Create a branch and sync it with upstream.
+
+```sh
+# create a branch
+git checkout -b myrevert
+
+# sync the branch with upstream
+git fetch upstream
+git rebase upstream/master
+```
+
+#### 2. Revert the prior commit(s)
+
+If the commit you wish to revert it a merge commit, run this:
+
+```sh
+# SHA is the hash of the merge commit you wish to revert
+git revert -m 1 SHA
+```
+
+If it is a single commit, then run the following:
+
+```sh
+# SHA is the hash of the single commit you wish to revert
+git revert SHA
+```
+
+The above will create a new commit reverting the changes.
+
+#### 3. Push this new commit to your remote.
+
+```sh
+git push ${your_remote_name} myrevert
+```
+
+#### 4. [Create a pull request](#7-create-a-pull-request) using this branch.
+
+## Community Guidelines
+
+This project follows [Google's Open Source Community
+Guidelines](https://opensource.google.com/conduct/).

--- a/docs/developers/dev_workflow.md
+++ b/docs/developers/dev_workflow.md
@@ -1,0 +1,31 @@
+# Developer Workflow
+
+> Steps outlined in this page assume that the [development prerequisites](prerequisites.md) are met. 
+
+## Create Workspace
+Before making your first contribution, you should follow the steps to 
+[create your own GitHub fork](contributing.md#1-fork-on-github) and 
+[local workspace as outlined in the contributor guide](contributing.md#2-clone-fork).
+
+After this, you can browse the code and start making changes as necessary.
+
+## Build and Test
+After you made some changes to the code locally, before opening a pull request you should run 
+a few steps to make sure the code will pass validation by the CI:
+
+* Run and pass `make build`
+* Run and pass `make test`
+
+You can find more information on the full build process in the [building onos-config](build.md) document.
+
+## Submit a Pull Request
+If the build and the test passed, you can commit your code and open a new pull request 
+as described in more detail in the [contributing to onos-config](contributing.md#5-commit) document.
+
+## Pull Request Review process
+The pull request you just opened will be checked by our Travis CI system and reviewed by the community. 
+Once it is approved, it will be merged it with a _squash and merge_ strategy. 
+If you are requested for changes in your pull request please go back and start again with [step number 4 
+in the contributing to onos-config guide](contributing.md#4-keep-branch-in-sync).
+
+

--- a/docs/developers/prerequisites.md
+++ b/docs/developers/prerequisites.md
@@ -1,0 +1,46 @@
+# Development Prerequisites
+This document provides an overview of the tools and packages needed to work on and to build onos-config.
+Developers are expected to have these tools installed on the machine where the project is built.
+
+## Go Tools
+Since the project is authored mainly in the Go programming language, the project requires [Go tools] 
+in order to build and execute the code.
+
+## Go Linters
+[golangci-lint] is required to validate that the Go source code complies with the established style 
+guidelines. To install the tool, use this command:
+```bash
+> curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin latest
+```
+
+## Docker
+[Docker] is required to build the project Docker images and also to compile `*.proto` files into Go source files.
+
+## Local kubernetes environment
+Some form of local kubernetes development environment is also needed.
+The core team uses [Kind], but there are other options such as [Minikube].
+
+## IDE
+Some form of an integrated development environment is also recommended.
+The core team uses the [GoLand IDE] from JetBrains, but there are many other options. 
+Microsoft's [Visual Studio Code] is one such option and is available as a free download.
+
+Note that when using [GoLand IDE] you should enable integration with Go modules in `Preferences -> Go -> Go Modules`.
+
+## License
+The project requires that all Go source files are properly annotated using the Apache 2.0 License.
+Since this requirement is enforced by the CI process, it is strongly recommended that developers
+setup their IDE to include the [license text](../build/licensing/boilerplate.go.txt)
+automatically.
+
+[GoLand IDE can be easily setup to do this](license_goland.md) and other IDEs will have a similar mechanism.
+
+
+[Go tools]: https://golang.org/doc/install
+[golangci-lint]: https://github.com/golangci/golangci-lint
+[Docker]: https://docs.docker.com/install/
+[Kind]: https://github.com/kubernetes-sigs/kind
+[Minikube]: https://kubernetes.io/docs/tasks/tools/install-minikube/
+
+[GoLand IDE]: /https://www.jetbrains.com/go/
+[Visual Studio Code]: /https://code.visualstudio.com


### PR DESCRIPTION
This is an initial commit to move some of the common docs from onos-config repo to this repo such as developer guidelines, contacts and meetings, etc. We still need to go through them and make them more generic. 