### PR TITLE
Add onos-docs-base image to reduce the build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,23 @@ docs-serve: deps build-docs-manager images
 build-docs-manager: # @HELP build docs-manager application
 	go build -o build/_output/docs-manager ./cmd/docs-manager
 
-images: # @HELP build docs-manager application image
+
+onos-docs-base-image:
+	docker build . -f build/base/Dockerfile \
+        		--build-arg DOCS_MANAGER_BUILD_VERSION=${DOCS_MANAGER_BUILD_VERSION} \
+        		-t onosproject/onos-docs-base:${DOCS_MANAGER_TEST_VERSION}
+
+onos-docs-manager-image:
 	@go mod vendor
 	docker build . -f build/docs-manager/Dockerfile \
-		--build-arg DOCS_MANAGER_BUILD_VERSION=${DOCS_MANAGER_BUILD_VERSION} \
-		-t onosproject/onos-docs-manager:${DOCS_MANAGER_TEST_VERSION}
+    		--build-arg DOCS_MANAGER_BUILD_VERSION=${DOCS_MANAGER_BUILD_VERSION} \
+    		-t onosproject/onos-docs-manager:${DOCS_MANAGER_TEST_VERSION}
 	@rm -rf vendor
+
+
+images: # @HELP build docs-manager application image
+images: onos-docs-manager-image
+
 
 linters: # @HELP examines Go source code and reports coding problems
 	golangci-lint run

--- a/build/base/Dockerfile
+++ b/build/base/Dockerfile
@@ -1,0 +1,13 @@
+FROM alpine:3.9
+RUN apk add libc6-compat
+RUN apk add --no-cache git
+RUN apk add --no-cache bash
+RUN apk add --no-cache openssh
+
+RUN apk --no-cache --no-progress add  py3-pip \
+  && pip3 install --user mkdocs==1.0.4 \
+  && pip3 install --user  pymdown-extensions==6.0 \
+  && pip3 install --user mkdocs-bootswatch==1.0 \
+  && pip3 install --user  mkdocs-material==4.0.2 \
+  && pip3 install --user  markdown-include==0.5.1 \
+

--- a/build/docs-manager/Dockerfile
+++ b/build/docs-manager/Dockerfile
@@ -5,14 +5,7 @@ ENV GO111MODULE=on
 COPY . /go/src/github.com/onosproject/onos-docs
 RUN cd /go/src/github.com/onosproject/onos-docs && GOFLAGS=-mod=vendor make build-docs-manager
 
-FROM alpine:3.9
-RUN apk add libc6-compat
-RUN apk add --no-cache git
-RUN apk add --no-cache bash
-RUN apk add --no-cache openssh
-
-
-USER root
+FROM onosproject/onos-docs-base:latest
 
 COPY --from=build /go/src/github.com/onosproject/onos-docs/build/_output/docs-manager /usr/local/bin/docs-manager
 

--- a/docs/docs.Dockerfile
+++ b/docs/docs.Dockerfile
@@ -5,6 +5,4 @@ COPY ./  /mkdocs
 WORKDIR /mkdocs
 VOLUME /mkdocs
 
-RUN apk --no-cache --no-progress add py3-pip \
-  && pip3 install --user -r requirements.txt
 


### PR DESCRIPTION
I added a base image for the mkdocs requirements. Before merging this PR, we need to push the base image to onosproject/onos-docs-base. 

@ray-milkey 
Please push the base image under build/base/Dockerfile to onosproject/onos-docs-base.
https://raw.githubusercontent.com/adibrastegarnia/onos-docs/add_base_image/build/base/Dockerfile
 