### PR TITLE
Remove verfication since we don't use it at this moment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ jobs:
       script:
         - make docs
         - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash ./build/bin/push-images; fi'
-    - stage : deploy
       deploy:
         - provider: pages
           edge: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ jobs:
         - make docs
         - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash ./build/bin/push-images; fi'
     - stage : deploy
-      if: type != pull_request
       deploy:
         - provider: pages
           edge: false

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
+
 # onos-docs
+[![Build Status](https://travis-ci.org/onosproject/onos-docs.svg?branch=master)](https://travis-ci.org/onosproject/onos-docs)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/onosproject/onos-docs/blob/master/LICENSE)
+[![Website](https://img.shields.io/website?url=https%3A%2F%2Fdocs.onosproject.org)](https://docs.onosproject.org)
+[![Go Report Card](https://goreportcard.com/badge/github.com/onosproject/onos-docs)](https://goreportcard.com/report/github.com/onosproject/onos-docs)
+[![GoDoc](https://godoc.org/github.com/onosproject/onos-docs?status.svg)](https://godoc.org/github.com/onosproject/onos-docs)
+
 Consolidated documentation for the ONOS project, available at [https://docs.onosproject.org](https://docs.onosproject.org).
 
 See [contributing.md](docs/content/developers/contributing.md) and

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -17,7 +17,7 @@ DOCKER_RUN_DOC_OPTS := --rm $(DOCKER_RUN_DOC_MOUNTS) -p $(DOCKER_RUN_DOC_PORT):8
 
 
 # Default: generates the documentation into $(SITE_DIR)
-docs: docs-clean docs-image docs-lint docs-build docs-verify
+docs: docs-clean docs-image docs-lint docs-build 
 
 # Writer Mode: build and serve docs on http://localhost:8000 with livereload
 docs-serve: docs-build


### PR DESCRIPTION
Later we should add the required packages for the markdown verification to the base image but for now since we don't use it, we should remove it from the build process. 
To address #45 
