### PR TITLE
enable markdown linter for onos-docs

### DIFF
--- a/build/base/Dockerfile
+++ b/build/base/Dockerfile
@@ -1,8 +1,7 @@
 FROM alpine:3.9
 RUN apk add libc6-compat
-RUN apk add --no-cache git
-RUN apk add --no-cache bash
-RUN apk add --no-cache openssh
+RUN apk add --no-cache git bash openssh ruby && \
+    gem install --no-rdoc --no-ri mdl
 
 RUN apk --no-cache --no-progress add  py3-pip \
   && pip3 install --user mkdocs==1.0.4 \
@@ -10,4 +9,3 @@ RUN apk --no-cache --no-progress add  py3-pip \
   && pip3 install --user mkdocs-bootswatch==1.0 \
   && pip3 install --user  mkdocs-material==4.0.2 \
   && pip3 install --user  markdown-include==0.5.1 \
-

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -8,19 +8,24 @@ SITE_DIR := $(CURDIR)/site
 DOCKER_RUN_DOC_PORT := 8000
 DOCKER_RUN_DOC_MOUNTS := -v $(CURDIR):/mkdocs 
 DOCKER_RUN_DOC_OPTS := --rm $(DOCKER_RUN_DOC_MOUNTS) -p $(DOCKER_RUN_DOC_PORT):8000
+MDL_DIRs := ./content/onos-config ./content/onos-topo ./content/onos-ztp ./content/onos-gui \
+            ./content/onos-cli/docs/setup.md ./content/developers ./content/onos-test
 
 
 # Default: generates the documentation into $(SITE_DIR)
-docs: docs-clean docs-image docs-build
+docs: docs-build docs-check
 
 # Writer Mode: build and serve docs on http://localhost:8000 with livereload
-docs-serve: docs-build
+docs-serve: docs-build docs-check
 	docker run -it  $(DOCKER_RUN_DOC_OPTS) $(ONOS_DOCS_BUILD_IMAGE) /bin/sh -c "cd "site" && python3 -m http.server 8000"
 
 
-# Utilities Targets for each step
+# Build onos-docs related images
 docs-image:
 	docker build -t $(ONOS_DOCS_BUILD_IMAGE) -f docs.Dockerfile ./
+
+docs-check:
+	docker run --rm -v $(DOCKER_RUN_DOC_OPTS) $(ONOS_DOCS_BUILD_IMAGE) mdl $(MDL_DIRs) -s md.style.rb
 
 docs-build: docs-clean docs-image
 	docker run -it  $(DOCKER_RUN_DOC_OPTS) $(ONOS_DOCS_BUILD_IMAGE) docs-manager ./configs/versions.yml ./content/ ./mkdocs.yml ./configs/menu/onos-menu.js.gotmpl ./configs/menu/onos-menu.css

--- a/docs/content/developers/contributing.md
+++ b/docs/content/developers/contributing.md
@@ -18,7 +18,7 @@ In the following examples just substitute any `onos-config` reference with the n
   
 ### 1. Fork on GitHub
 
-1. Visit https://github.com/onosproject/onos-config 
+1. Visit <https://github.com/onosproject/onos-config> 
 2. Click `Fork` button (top right) to establish your own GitHub repository fork.
 
 ### 2. Clone Fork
@@ -174,7 +174,7 @@ _If you have upstream write access_, please refrain from using the
 `Revert` button in the GitHub UI for creating the PR, because GitHub
 will create the PR branch inside the main repository rather than inside your fork.
 
-#### 1. Create a branch and sync it with upstream.
+#### 1. Create a branch and sync it with upstream
 
 ```sh
 # create a branch
@@ -203,13 +203,13 @@ git revert SHA
 
 The above will create a new commit reverting the changes.
 
-#### 3. Push this new commit to your remote.
+#### 3. Push this new commit to your remote
 
 ```sh
 git push ${your_remote_name} myrevert
 ```
 
-#### 4. [Create a pull request](#7-create-a-pull-request) using this branch.
+#### 4. [Create a pull request](#7-create-a-pull-request) using this branch
 
 ## Community Guidelines
 

--- a/docs/content/developers/documentation.md
+++ b/docs/content/developers/documentation.md
@@ -1,4 +1,4 @@
-# How does onos-docs work? 
+# How does onos-docs work?
 *Multi-repo docs* is a process that collects docs from multiple repos and publishes them on a single website. 
 [µONOS](https://github.com/onosproject) project uses the Multi-repo docs process to achieve following design goals:
 
@@ -7,7 +7,7 @@ each subsystem. In addition, [onos-docs](https://github.com/onosproject/onos-doc
 - *Easy to maintain*: Support adding new projects and their docs in the building and publishing process of onos docs with a minimum effort.
 - *Versioning*: Support versioning to build different version of docs based on different releases of ONOS subsystems. 
 
-## ONOS Docs Manager Software:
+## ONOS Docs Manager Software
 onos-docs project uses [Mkdocs] for building the docs website and [Travis] to publish it on web.  
 To automate the workflow and  achieve the above design goals, 
 a software is developed called *onos-docs-manager* that is written in Golang 
@@ -70,9 +70,9 @@ Rules for GitHub markdown are at [https://guides.github.com/features/mastering-m
 
 Rules for MkDocs (Python) are at [https://daringfireball.net/projects/markdown/syntax](https://daringfireball.net/projects/markdown/syntax)
 
-> The rules are mostly the same for both platforms, with the following caveats
->
->   * With the python interpreter there must be a new empty line before any ordered or unordered list
+The rules are mostly the same for both platforms, with the following caveats:
+
+- With the python interpreter there must be a new empty line before any ordered or unordered list
 
 
 [onos-docs]: https://github.com/onosproject/onos-docs

--- a/docs/content/developers/pull_requests.md
+++ b/docs/content/developers/pull_requests.md
@@ -51,14 +51,11 @@ Fixes #90
 #       modified:   docs/Pull_requests.md
 #
 ```
-
 ### Open a Pull Request
 When you open a pull request for _myfeature_ you need to add the PR to a `project` (e.g. Northbound) through the github UI. 
 Please also assign a reviewer out of the suggested ones. If none are suggested please pick one from the core team.     
 
 More information on opening pull requests can be found [in the GitHub documentation](https://help.github.com/en/articles/creating-a-pull-request).
-
-
 ### Track a Pull Request
 After your pull request is included into a onos-config _project_ you can find it under the `In Progress` tab.  
 At this point in time the PR will go through a lifecycle:

--- a/docs/md.style.rb
+++ b/docs/md.style.rb
@@ -1,0 +1,19 @@
+rule "MD001" # header levels increment by 1
+rule "MD003", :style => :atx # header style - atx
+rule "MD004", :style => :consistent # unordered list style - consistent
+rule "MD005" # don't allow inconsistent indentation for list items
+rule "MD006" # start bullets at beginning of line
+rule "MD011" # Reversed link syntax
+rule "MD014" # Dollar signs used before commands without showing output
+rule "MD018" # No space after hash on atx style header
+rule "MD023" # Headers must start at the beginning of the line
+rule "MD024" # no multiple headers with same content
+rule "MD028" # no blank lines within blockquote
+rule "MD034" # Bare URL used
+rule "MD037" # Spaces inside emphasis markers
+rule "MD038" # Spaces inside code span elements
+rule "MD039" # Spaces inside link text
+rule "MD040" # Fenced code blocks should have a language specified
+rule "MD046" #  Code block style
+
+


### PR DESCRIPTION
To address issue #65 . We should merge the PRs related to the markdown linter in other repos first. 
We enabled the following rules: 

```
rule "MD001" # header levels increment by 1
rule "MD003", :style => :atx # header style - atx
rule "MD004", :style => :consistent # unordered list style - consistent
rule "MD005" # don't allow inconsistent indentation for list items
rule "MD006" # start bullets at beginning of line
rule "MD011" # Reversed link syntax
rule "MD014" # Dollar signs used before commands without showing output
rule "MD018" # No space after hash on atx style header
rule "MD023" # Headers must start at the beginning of the line
rule "MD024" # no multiple headers with same content
rule "MD028" # no blank lines within blockquote
rule "MD034" # Bare URL used
rule "MD037" # Spaces inside emphasis markers
rule "MD038" # Spaces inside code span elements
rule "MD039" # Spaces inside link text
rule "MD040" # Fenced code blocks should have a language specified
rule "MD046" #  Code block style
```
For more information: https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md

