### PR TITLE
Use minify html to remove whitespaces automatically

### DIFF
--- a/build/base/Dockerfile
+++ b/build/base/Dockerfile
@@ -9,3 +9,4 @@ RUN apk --no-cache --no-progress add  py3-pip \
   && pip3 install --user mkdocs-bootswatch==1.0 \
   && pip3 install --user  mkdocs-material==4.0.2 \
   && pip3 install --user  markdown-include==0.5.1 \
+  && pip3 install --user mkdocs-minify-plugin \

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -17,6 +17,10 @@ markdown_extensions:
 - admonition
 - footnotes
 nav: null
+plugins:
+- search
+- minify:
+    minify_html: true
 repo_name: onosproject
 repo_url: https://github.com/onosproject
 site_author: Open Networking Foundation


### PR DESCRIPTION
mkdocs-minify-plugin is an extension that minifies HTML by stripping all whitespace from the generated documentation.