### PR TITLE
Removing the onos-topo name override for config values.

### DIFF
--- a/docs/content/developers/deploy_with_helm.md
+++ b/docs/content/developers/deploy_with_helm.md
@@ -87,7 +87,7 @@ Once you have exported the `KUBECONFIG` flag you can start deploy `onos` service
 A complete set of onos services can be deployed with just the [`onos` chart](https://github.com/onosproject/onos-helm-charts/tree/master/onos). 
 In the root directory of the `onos-helm-chart` repository issue
 ```bash
-helm install -n micro-onos onos onos --set onos-config.topoEndpoint=onos-onos-topo:5150
+helm install -n micro-onos onos onos
 ```
 
 this will deploy `onos-config`, `onos-topo`, `onos-cli` and `onos-gui`. 


### PR DESCRIPTION
With the name override for each service in place in the charts, overriding the topo enpoint is not needed anymore.